### PR TITLE
Switch to indexed applicatives

### DIFF
--- a/free-categories.cabal
+++ b/free-categories.cabal
@@ -16,6 +16,7 @@ extra-source-files:  CHANGELOG.md, README.md
 
 library
   exposed-modules:     Control.Category.Free
+                       Control.Atkey
                        Data.Quiver
                        Data.Quiver.Bifunctor
                        Data.Quiver.Functor

--- a/free-categories.cabal
+++ b/free-categories.cabal
@@ -20,6 +20,7 @@ library
                        Data.Quiver
                        Data.Quiver.Bifunctor
                        Data.Quiver.Functor
+  other-modules:       Data.Quiver.Internal
   build-depends:       base >=4.12 && <=5
   hs-source-dirs:      src
   default-language:    Haskell2010

--- a/src/Control/Atkey.hs
+++ b/src/Control/Atkey.hs
@@ -13,6 +13,7 @@ module Control.Atkey
   , IxApplicative (..)
   , IxConst (..)
   , WrappedApplicative (..)
+  , IxBackwards (..)
   ) where
 
 import Control.Category
@@ -59,3 +60,12 @@ instance Category d => IxApply (IxConst d) where
   iap (IxConst x) (IxConst y) = IxConst (y . x)
 instance Category d => IxApplicative (IxConst d) where
   ipure _ = IxConst id
+
+newtype IxBackwards f y x a = IxBackwards { ixforwards :: f x y a }
+  deriving (Eq, Ord, Show)
+instance IxFunctor f => IxFunctor (IxBackwards f) where
+  imap = ((IxBackwards .) . (. ixforwards)) #. imap
+instance IxApply f => IxApply (IxBackwards f) where
+  iliftA2 f (IxBackwards x) (IxBackwards y) = IxBackwards $ iliftA2 (flip f) y x
+instance IxApplicative f => IxApplicative (IxBackwards f) where
+  ipure = IxBackwards #. ipure

--- a/src/Control/Atkey.hs
+++ b/src/Control/Atkey.hs
@@ -1,0 +1,37 @@
+{-# language PolyKinds #-}
+{-# language RankNTypes #-}
+
+-- | A polykinded and modified copy of @Data.Functor.Indexed@ from the moribund
+-- @indexed@ package.
+module Control.Atkey
+  ( IxFunctor (..)
+  , IxApply (..)
+  , IxApplicative (..)
+  , IxConst (..)
+  ) where
+
+import Control.Category
+import Prelude hiding (id, (.))
+
+class IxFunctor f where
+  infixl 4 `imap`
+  imap :: (a -> b) -> f j k a -> f j k b
+
+class IxFunctor m => IxApply m where
+  {-# MINIMAL iap | iliftA2 #-}
+  infixl 4 `iap`
+  iap :: m i j (a -> b) -> m j k a -> m i k b
+  iap = iliftA2 id
+  iliftA2 :: (a -> b -> c) -> m i j a -> m j k b -> m i k c
+  iliftA2 f x y = f `imap` x `iap` y
+
+class IxApply m => IxApplicative m where
+  ipure :: a -> m i i a
+
+newtype IxConst d x y z = IxConst { getIxConst :: d x y }
+instance IxFunctor (IxConst d) where
+  imap _ (IxConst x) = IxConst x
+instance Category d => IxApply (IxConst d) where
+  iap (IxConst x) (IxConst y) = IxConst (y . x)
+instance Category d => IxApplicative (IxConst d) where
+  ipure _ = IxConst id

--- a/src/Control/Atkey.hs
+++ b/src/Control/Atkey.hs
@@ -1,5 +1,9 @@
 {-# language PolyKinds #-}
 {-# language RankNTypes #-}
+{-# language GeneralizedNewtypeDeriving #-}
+{-# language StandaloneDeriving #-}
+{-# language ScopedTypeVariables #-}
+{-# language InstanceSigs #-}
 
 -- | A polykinded and modified copy of @Data.Functor.Indexed@ from the moribund
 -- @indexed@ package.
@@ -8,9 +12,13 @@ module Control.Atkey
   , IxApply (..)
   , IxApplicative (..)
   , IxConst (..)
+  , WrappedApplicative (..)
   ) where
 
 import Control.Category
+import Data.Coerce
+import Data.Quiver.Internal
+import Control.Applicative (liftA2)
 import Prelude hiding (id, (.))
 
 class IxFunctor f where
@@ -28,7 +36,23 @@ class IxFunctor m => IxApply m where
 class IxApply m => IxApplicative m where
   ipure :: a -> m i i a
 
+newtype WrappedApplicative f x y a = WrappedApplicative { getWrappedApplicative :: f a }
+  deriving (Eq, Ord, Show, Functor, Applicative)
+instance Functor f => IxFunctor (WrappedApplicative f) where
+  imap = ((WrappedApplicative .) . (. getWrappedApplicative)) #. fmap
+instance Applicative f => IxApply (WrappedApplicative f) where
+  iap :: forall a b i j k.
+    WrappedApplicative f i j (a -> b) -> WrappedApplicative f j k a -> WrappedApplicative f i k b
+  iap = coerce ((<*>) :: f (a -> b) -> f a -> f b)
+
+  iliftA2 :: forall a b c i j k.
+    (a -> b -> c) -> WrappedApplicative f i j a -> WrappedApplicative f j k b -> WrappedApplicative f i k c
+  iliftA2 = coerce (liftA2 :: (a -> b -> c) -> f a -> f b -> f c)
+instance Applicative f => IxApplicative (WrappedApplicative f) where
+  ipure = WrappedApplicative #. pure
+
 newtype IxConst d x y z = IxConst { getIxConst :: d x y }
+  deriving (Eq, Ord, Show)
 instance IxFunctor (IxConst d) where
   imap _ (IxConst x) = IxConst x
 instance Category d => IxApply (IxConst d) where

--- a/src/Control/Category/Free.hs
+++ b/src/Control/Category/Free.hs
@@ -59,6 +59,7 @@ module Control.Category.Free
 import Data.Quiver
 import Data.Quiver.Functor
 import Control.Category
+import Control.Atkey
 import Control.Monad (join)
 import Prelude hiding (id, (.))
 
@@ -100,11 +101,11 @@ instance QFoldable Path where
   qtoMonoid f (p :>> ps) = f p <> qtoMonoid f ps
   qtoList _ Done = []
   qtoList f (p :>> ps) = f p : qtoList f ps
-  qtraverse_ _ Done = pure id
-  qtraverse_ f (p :>> ps) = (>>>) <$> f p <*> qtraverse_ f ps
+  qtraverse_ _ Done = ipure id
+  qtraverse_ f (p :>> ps) = iliftA2 (>>>) (f p) (qtraverse_ f ps)
 instance QTraversable Path where
-  qtraverse _ Done = pure Done
-  qtraverse f (p :>> ps) = (:>>) <$> f p <*> qtraverse f ps
+  qtraverse _ Done = ipure Done
+  qtraverse f (p :>> ps) = iliftA2 (:>>) (f p) (qtraverse f ps)
 instance QPointed Path where qsingle p = p :>> Done
 instance QMonad Path where qjoin = qfold
 instance CFree Path
@@ -121,7 +122,7 @@ instance Category (FoldPath p) where
 instance QFunctor FoldPath where qmap f = qfoldMap (qsingle . f)
 instance QFoldable FoldPath where qfoldMap k (FoldPath f) = f k
 instance QTraversable FoldPath where
-  qtraverse f = getApQ . qfoldMap (ApQ . fmap qsingle . f)
+  qtraverse f = getIxApQ . qfoldMap (IxApQ . imap qsingle . f)
 instance QPointed FoldPath where qsingle p = FoldPath $ \ k -> k p
 instance QMonad FoldPath where qjoin (FoldPath f) = f id
 instance CFree FoldPath

--- a/src/Data/Quiver.hs
+++ b/src/Data/Quiver.hs
@@ -26,6 +26,7 @@ Many Haskell typeclasses are constraints on quivers, such as
   , QuantifiedConstraints
   , RankNTypes
   , StandaloneDeriving
+  , UndecidableInstances
 #-}
 
 module Data.Quiver
@@ -33,6 +34,7 @@ module Data.Quiver
   , OpQ (..)
   , IsoQ (..)
   , ApQ (..)
+  , IxApQ (..)
   , KQ (..)
   , ProductQ (..)
   , qswap
@@ -44,6 +46,7 @@ module Data.Quiver
   ) where
 
 import Control.Category
+import Control.Atkey
 import Control.Monad (join)
 import Prelude hiding (id, (.))
 
@@ -83,6 +86,18 @@ instance (Applicative m, Category c, x ~ y)
 instance (Applicative m, Category c) => Category (ApQ m c) where
   id = ApQ (pure id)
   ApQ g . ApQ f = ApQ ((.) <$> g <*> f)
+
+newtype IxApQ m c x y = IxApQ {getIxApQ :: m x y (c x y)}
+deriving instance Eq (m x y (c x y)) => Eq (IxApQ m c x y)
+deriving instance Ord (m x y (c x y)) => Ord (IxApQ m c x y)
+deriving instance Show (m x y (c x y)) => Show (IxApQ m c x y)
+instance (IxApplicative m, Category c, x ~ y)
+  => Semigroup (IxApQ m c x y) where (<>) = (>>>)
+instance (IxApplicative m, Category c, x ~ y)
+  => Monoid (IxApQ m c x y) where mempty = id
+instance (IxApplicative m, Category c) => Category (IxApQ m c) where
+  id = IxApQ (ipure id)
+  IxApQ g . IxApQ f = IxApQ (iliftA2 (flip (.)) f g)
 
 {- | The constant quiver.
 

--- a/src/Data/Quiver/Functor.hs
+++ b/src/Data/Quiver/Functor.hs
@@ -50,6 +50,7 @@ class QFunctor c where
 instance QFunctor (ProductQ p) where qmap f (ProductQ p q) = ProductQ p (f q)
 instance QFunctor (HomQ p) where qmap g (HomQ f) = HomQ (g . f)
 instance Functor t => QFunctor (ApQ t) where
+  -- There must be a clearer way to write this directly using coerce.
   qmap = ((ApQ .) . (. getApQ)) #. fmap
 instance QFunctor OpQ where qmap f = OpQ #. f .# getOpQ
 instance QFunctor IsoQ where qmap f (IsoQ u d) = IsoQ (f u) (f d)

--- a/src/Data/Quiver/Internal.hs
+++ b/src/Data/Quiver/Internal.hs
@@ -1,0 +1,12 @@
+module Data.Quiver.Internal where
+import Data.Coerce
+
+-- Borrowed from Data.Profunctor and specialized to ->
+
+infixr 9 #.
+(#.) :: Coercible b c => p b c -> (a -> b) -> a -> c
+(#.) _ = coerce
+
+infixl 8 .#
+(.#) :: Coercible a b => (b -> c) -> p a b -> a -> c
+f .# _ = coerce f


### PR DESCRIPTION
* The original `qtraverse` wasn't powerful enough to implement
  `qfoldMapDefault`. Using an *indexed* applicative makes it so.
* Add `qfoldMapDefault`.
* Adjust the type of `traverse_` to match.
* Remove the surprising `QFunctor` superclass of `QFoldable`.

Closes #10